### PR TITLE
Rule added for supported regions

### DIFF
--- a/ci/config.yml
+++ b/ci/config.yml
@@ -2,19 +2,17 @@ global:
   notification: true
   owner: mcguire7@uk.ibm.com
   project: quickstart-ibm-mq
-  qsname: quickstart-ibm-mq
-  reporting: true
+  qsname: ibm-mq-aws-quickstart
   regions:
     - us-east-1
     - us-east-2
     - us-west-2
     - eu-west-1
     - ap-southeast-2
-  report_email-to-owner: true
-  report_publish-to-s3: true
-  report_s3bucket: ibm-mq-quickstart
-  s3bucket: ibm-mq-quickstart
+  reporting: true
 tests:
   quickstart-ibm-mqt1:
     parameter_input: ibm-mq-quickstart-master.params.json
     template_file: ibm-mq-quickstart-master.template
+    region:
+      - us-east-1

--- a/templates/ibm-mq-quickstart-master.template
+++ b/templates/ibm-mq-quickstart-master.template
@@ -397,3 +397,17 @@ Resources:
           'Fn::GetAtt':
             - VPCStack
             - Outputs.VPCID
+Rules:
+  EFSSupportedRegionRule:
+    Assertions:
+      - Assert:
+          'Fn::Contains':
+          -
+            - 'us-east-1'
+            - 'us-east-2'
+            - 'us-west-2'
+            - 'eu-west-1'
+            - 'ap-southeast-2'
+          - !Ref "AWS::Region"
+        AssertDescription: "This Quick Start utilizes Amazon EFS which is only available in the US East (N. Virginia),
+        US East (Ohio), US West (Oregon), EU (Ireland) and Asia Pacific (Sydney) regions. Please launch the stack in one of these regions"

--- a/templates/ibm-mq-quickstart.template
+++ b/templates/ibm-mq-quickstart.template
@@ -591,7 +591,7 @@ Resources:
         'Fn::Join':
           - ''
           - - |
-            - ibm-mq-quickstart-elb
+            - ibm-mq-quickstart-elb-
             - !Ref QueueManagerName
             - |
       Listeners:
@@ -638,3 +638,17 @@ Outputs:
   ReadMeInfo:
     Description: 'For more information and details visit:'
     Value: 'https://github.com/aws-quickstart/ibm-mq-quickstart'
+Rules:
+  EFSSupportedRegionRule:
+    Assertions:
+      - Assert:
+          'Fn::Contains':
+          -
+            - 'us-east-1'
+            - 'us-east-2'
+            - 'us-west-2'
+            - 'eu-west-1'
+            - 'ap-southeast-2'
+          - !Ref "AWS::Region"
+        AssertDescription: "This Quick Start utilizes Amazon EFS which is only available in the US East (N. Virginia),
+        US East (Ohio), US West (Oregon), EU (Ireland) and Asia Pacific (Sydney) regions. Please launch the stack in one of these regions"


### PR DESCRIPTION
Block stack deployment with error message if launched in unsupported region.

Minor updates to CI test config and CF templates.