### PR TITLE
update templates with new IBM MQ 9.1.1 AMI

### DIFF
--- a/templates/ibm-mq-master.template
+++ b/templates/ibm-mq-master.template
@@ -1,5 +1,5 @@
 ---
-# © Copyright IBM Corporation 2017
+# © Copyright IBM Corporation 2017, 2018
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,12 +14,12 @@
 # limitations under the License.
 AWSTemplateFormatVersion: '2010-09-09'
 Description: This master template creates a VPC infrastructure for a multi-AZ, multi-tier
-  deployment of IBM MQ 9.0.3 on AWS EC2, with EFS. It deploys a VPC with bastions
+  deployment of IBM MQ 9.1.1 on AWS EC2, with EFS. It deploys a VPC with bastions
   and the IBM MQ solution. The IBM MQ solution is configured to use an EFS for persistant
   storage of the MQ volume. **WARNING** This template creates EC2 instances and related
   resources. You will be billed for the AWS resources used if you create a stack from
   this template. IBM MQ is licensed seperatley, please review the terms and conditions
-  here (http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=Z125-3301-14&li_formnum=L-APIG-AKHJ8V)
+  here (https://www14.software.ibm.com/cgi-bin/weblap/lap.pl?popup=Y&li_formnum=L-APIG-AZYF4X)
   for further details. (qs-1nhqnkuin)
 Metadata:
   AWS::CloudFormation::Interface:
@@ -223,7 +223,7 @@ Parameters:
       to securely connect to your instance after it launches
     Type: AWS::EC2::KeyPair::KeyName
   LicenseAgreement:
-    Description: I have read and agree to the license terms for IBM MQ (http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=Z125-3301-14&li_formnum=L-APIG-AKHJ8V).
+    Description: I have read and agree to the license terms for IBM MQ (https://www14.software.ibm.com/cgi-bin/weblap/lap.pl?popup=Y&li_formnum=L-APIG-AZYF4X).
     Type: String
     Default: '-'
     AllowedValues:

--- a/templates/ibm-mq.template
+++ b/templates/ibm-mq.template
@@ -1,5 +1,5 @@
 ---
-# © Copyright IBM Corporation 2017
+# © Copyright IBM Corporation 2017, 2018
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 AWSTemplateFormatVersion: '2010-09-09'
-Description: This template creates a deployment of IBM MQ 9.0.3 on AWS EC2, with EFS,
+Description: This template creates a deployment of IBM MQ 9.1.1 on AWS EC2, with EFS,
   within an existing VPC and Bastion server environment. The IBM MQ solution is configured
   to use an EFS for persistant storage of the MQ volume. **WARNING** This template creates EC2
   instances and related resources. You will be billed for the AWS resources used if you create
   a stack from this template. IBM MQ is licensed seperatley, please review the terms and conditions
-  here (http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=Z125-3301-14&li_formnum=L-APIG-AKHJ8V)
+  here (https://www14.software.ibm.com/cgi-bin/weblap/lap.pl?popup=Y&li_formnum=L-APIG-AZYF4X)
   for further details. (qs-1nhqnkuii)
 Metadata:
   AWS::CloudFormation::Interface:
@@ -185,7 +185,7 @@ Parameters:
       this key pair.
     Type: AWS::EC2::KeyPair::KeyName
   LicenseAgreement:
-    Description: I have read and agree to the license terms for IBM MQ (http://www14.software.ibm.com/cgi-bin/weblap/lap.pl?la_formnum=Z125-3301-14&li_formnum=L-APIG-AKHJ8V).
+    Description: I have read and agree to the license terms for IBM MQ (https://www14.software.ibm.com/cgi-bin/weblap/lap.pl?popup=Y&li_formnum=L-APIG-AZYF4X).
     Type: String
     Default: '-'
     AllowedValues:
@@ -298,17 +298,17 @@ Rules:
 Mappings:
   AWSAMIRegionMap:
     AMI:
-      IBMMQ903US1604: MQ_903_Ubuntu_1604
+      IBMMQ911US1604: MQ_911_Ubuntu_1604
     ap-southeast-2:
-      IBMMQ903US1604: ami-e9fee18a
+      IBMMQ911US1604: ami-0617c3daa1aebd02d
     eu-west-1:
-      IBMMQ903US1604: ami-5f658d26
+      IBMMQ911US1604: ami-0b9cdceb787870bd4
     us-east-1:
-      IBMMQ903US1604: ami-d0cf92ab
+      IBMMQ911US1604: ami-0a0c96cb1ba7f4f29
     us-east-2:
-      IBMMQ903US1604: ami-66230303
+      IBMMQ911US1604: ami-049d47f4e4d22bc18
     us-west-2:
-      IBMMQ903US1604: ami-017a6078
+      IBMMQ911US1604: ami-01f2cc55fb8954fef
 Conditions:
   GovCloudCondition:
     Fn::Equals:
@@ -451,7 +451,7 @@ Resources:
         Fn::FindInMap:
         - AWSAMIRegionMap
         - !Ref AWS::Region
-        - IBMMQ903US1604
+        - IBMMQ911US1604
       InstanceType: !Ref MQInstanceType
       KeyName: !Ref KeyPairName
       SecurityGroups:
@@ -542,7 +542,7 @@ Outputs:
   MQRestApiURL:
     Description: URL for Elastic Load Balancer to connect to REST API
     Value:
-      Fn::Sub: https://${LoadBalancer.DNSName}:9443/ibmmq/rest/v1/
+      Fn::Sub: https://${LoadBalancer.DNSName}:9443/ibmmq/rest/v1/admin/
   MQConsoleURL:
     Description: URL for Elastic Load Balancer to connect to MQ Console
     Value:


### PR DESCRIPTION
This change set introduces the newly updated AMI for the new version of IBM MQ, v9.1.1
