### PR TITLE
Update Quickstart to MQ Version 9.2.0

### DIFF
--- a/templates/ibm-mq-master.template
+++ b/templates/ibm-mq-master.template
@@ -1,5 +1,5 @@
 ---
-# © Copyright IBM Corporation 2017
+# © Copyright IBM Corporation 2017, 2020
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # limitations under the License.
 AWSTemplateFormatVersion: '2010-09-09'
 Description: This master template creates a VPC infrastructure for a multi-AZ, multi-tier
-  deployment of IBM MQ 9.0.3 on AWS EC2, with EFS. It deploys a VPC with bastions
+  deployment of IBM MQ 9.2.0 on AWS EC2, with EFS. It deploys a VPC with bastions
   and the IBM MQ solution. The IBM MQ solution is configured to use an EFS for persistant
   storage of the MQ volume. **WARNING** This template creates EC2 instances and related
   resources. You will be billed for the AWS resources used if you create a stack from

--- a/templates/ibm-mq.template
+++ b/templates/ibm-mq.template
@@ -1,5 +1,5 @@
 ---
-# © Copyright IBM Corporation 2017
+# © Copyright IBM Corporation 2017, 2020
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 AWSTemplateFormatVersion: '2010-09-09'
-Description: This template creates a deployment of IBM MQ 9.0.3 on AWS EC2, with EFS,
+Description: This template creates a deployment of IBM MQ 9.2.0 on AWS EC2, with EFS,
   within an existing VPC and Bastion server environment. The IBM MQ solution is configured
   to use an EFS for persistant storage of the MQ volume. **WARNING** This template creates EC2
   instances and related resources. You will be billed for the AWS resources used if you create
@@ -298,37 +298,37 @@ Rules:
 Mappings:
   AWSAMIRegionMap:
     AMI:
-      IBMMQ911US1604: MQ_911_Ubuntu_1604
+      IBMMQ920US1804: MQ_920_Ubuntu_1804
     ap-southeast-1:
-      IBMMQ911US1604: ami-03cd5fd2e3d377204
+      IBMMQ920US1804: ami-09b38aa9cbaf732e6
     ap-southeast-2:
-      IBMMQ911US1604: ami-014fc0f529b984c13
+      IBMMQ920US1804: ami-0350fd1db46c1f9ba
     ap-south-1:
-      IBMMQ911US1604: ami-04ab5a570952b7bfe
+      IBMMQ920US1804: ami-01d4be211aa3f2284
     ap-northeast-1:
-      IBMMQ911US1604: ami-0195d8f6fd1c4a7b8
+      IBMMQ920US1804: ami-01de29cacd131bc20
     ap-northeast-2:
-      IBMMQ911US1604: ami-0376d061b082d0746
+      IBMMQ920US1804: ami-07cb269a2c82adaa6
     ca-central-1:
-      IBMMQ911US1604: ami-0b09f573fbc68b78b
+      IBMMQ920US1804: ami-0bb500f417be25bbc
     eu-central-1: 
-      IBMMQ911US1604: ami-000ae9e026f308433
+      IBMMQ920US1804: ami-07bbee62753b9d20f
     eu-west-1:
-      IBMMQ911US1604: ami-0aac3a846b4bdbeb1
+      IBMMQ920US1804: ami-0584dc442ad6b24ed
     eu-west-2:
-      IBMMQ911US1604: ami-01ffb098d1f14ce44
+      IBMMQ920US1804: ami-01e1802edd9fe40c0
     eu-west-3:
-      IBMMQ911US1604: ami-0040ca95b9ab561f2
+      IBMMQ920US1804: ami-02ff07b5f68a1f659
     sa-east-1:
-      IBMMQ911US1604: ami-0a5d4117561bb7800
+      IBMMQ920US1804: ami-053006db69b0e221b
     us-east-1:
-      IBMMQ911US1604: ami-0fb470eee385153f5
+      IBMMQ920US1804: ami-0eeb95a87a14983db
     us-east-2:
-      IBMMQ911US1604: ami-093e5008d65af14c5
+      IBMMQ920US1804: ami-0b0c3c984874d1b89
     us-west-1:
-      IBMMQ911US1604: ami-0e0fc582586e57fac
+      IBMMQ920US1804: ami-0fc883f54130173bb
     us-west-2:
-      IBMMQ911US1604: ami-0749e2094b4cfdc37
+      IBMMQ920US1804: ami-089b4a9133b486a6a
 Conditions:
   GovCloudCondition:
     Fn::Equals:
@@ -471,7 +471,7 @@ Resources:
         Fn::FindInMap:
         - AWSAMIRegionMap
         - !Ref AWS::Region
-        - IBMMQ903US1604
+        - IBMMQ920US1804
       InstanceType: !Ref MQInstanceType
       KeyName: !Ref KeyPairName
       SecurityGroups:

--- a/templates/ibm-mq.template
+++ b/templates/ibm-mq.template
@@ -298,17 +298,37 @@ Rules:
 Mappings:
   AWSAMIRegionMap:
     AMI:
-      IBMMQ903US1604: MQ_903_Ubuntu_1604
+      IBMMQ911US1604: MQ_911_Ubuntu_1604
+    ap-southeast-1:
+      IBMMQ911US1604: ami-03cd5fd2e3d377204
     ap-southeast-2:
-      IBMMQ903US1604: ami-e9fee18a
+      IBMMQ911US1604: ami-014fc0f529b984c13
+    ap-south-1:
+      IBMMQ911US1604: ami-04ab5a570952b7bfe
+    ap-northeast-1:
+      IBMMQ911US1604: ami-0195d8f6fd1c4a7b8
+    ap-northeast-2:
+      IBMMQ911US1604: ami-0376d061b082d0746
+    ca-central-1:
+      IBMMQ911US1604: ami-0b09f573fbc68b78b
+    eu-central-1: 
+      IBMMQ911US1604: ami-000ae9e026f308433
     eu-west-1:
-      IBMMQ903US1604: ami-5f658d26
+      IBMMQ911US1604: ami-0aac3a846b4bdbeb1
+    eu-west-2:
+      IBMMQ911US1604: ami-01ffb098d1f14ce44
+    eu-west-3:
+      IBMMQ911US1604: ami-0040ca95b9ab561f2
+    sa-east-1:
+      IBMMQ911US1604: ami-0a5d4117561bb7800
     us-east-1:
-      IBMMQ903US1604: ami-d0cf92ab
+      IBMMQ911US1604: ami-0fb470eee385153f5
     us-east-2:
-      IBMMQ903US1604: ami-66230303
+      IBMMQ911US1604: ami-093e5008d65af14c5
+    us-west-1:
+      IBMMQ911US1604: ami-0e0fc582586e57fac
     us-west-2:
-      IBMMQ903US1604: ami-017a6078
+      IBMMQ911US1604: ami-0749e2094b4cfdc37
 Conditions:
   GovCloudCondition:
     Fn::Equals:


### PR DESCRIPTION
Update templates to use the new version of IBM MQ 9.2.0 AMI


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
